### PR TITLE
fixed axe_beserkers_call_owner particle

### DIFF
--- a/game/scripts/npc/abilities/antimage_blink_datadriven.txt
+++ b/game/scripts/npc/abilities/antimage_blink_datadriven.txt
@@ -63,13 +63,6 @@
 			"Target"		"CASTER"
 		}
 
-		"AttachEffect"
-		{
-			"EffectName"	"particles/units/heroes/hero_antimage/antimage_blink_start.vpcf"
-			"Target"		"CASTER"
-			"EffectAttachType"	"attach_hitloc"
-		}
-
 		"FireSound"
 		{
 			"EffectName"	"Hero_Antimage.Blink_in"

--- a/game/scripts/npc/abilities/axe_berserkers_call_datadriven.txt
+++ b/game/scripts/npc/abilities/axe_berserkers_call_datadriven.txt
@@ -65,17 +65,10 @@
 			"Target" 		"CASTER"
 		}
 
-		"FireEffect"
+		"RemoveModifier"
 		{
-			"EffectName"        "particles/units/heroes/hero_axe/axe_beserkers_call_owner.vpcf"
-			"EffectAttachType"  "start_at_customorigin"
-
-			"ControlPointEntities"
-			{
-				"CASTER"	"follow_origin"
-				"CASTER"	"follow_origin"
-				"CASTER"	"follow_origin"
-			}
+			"ModifierName"	"modifier_berserkers_call_caster_datadriven"
+			"Target" 		"CASTER"
 		}
 
 		"ApplyModifier"
@@ -114,6 +107,26 @@
 		{
 			"IsPurgable"		"0"
 			"IsBuff"			"1"
+	
+			"OnCreated"
+			{
+				"AttachEffect"
+				{
+					"Target"			"CASTER"
+					"EffectName"        "particles/units/heroes/hero_axe/axe_beserkers_call_owner.vpcf"
+					"EffectAttachType" 	"follow_origin"
+					"ControlPoints"
+					{
+						"02"		"%radius 1 1"	//Required for Rampant Outrage (axe immortal)
+					}
+					"ControlPointEntities"
+					{
+						"CASTER"	"follow_origin"
+						"CASTER"	"follow_origin"
+						"CASTER"	"follow_origin"
+					}
+				}
+			}
 	
 			"Properties"
 			{

--- a/game/scripts/vscripts/heroes/hero_antimage/blink.lua
+++ b/game/scripts/vscripts/heroes/hero_antimage/blink.lua
@@ -17,4 +17,11 @@ function Blink(keys)
 
 	FindClearSpaceForUnit(caster, point, false)
 	ProjectileManager:ProjectileDodge(caster)
+	
+	local blinkIndex = ParticleManager:CreateParticle("particles/units/heroes/hero_antimage/antimage_blink_start.vpcf", PATTACH_ABSORIGIN, caster)
+	Timers:CreateTimer( 1, function()
+		ParticleManager:DestroyParticle( blinkIndex, false )
+		return nil
+		end
+	)
 end


### PR DESCRIPTION
the particle now correctly applies glow effect to axe's body when casted.
additionally fixed bug when the spell was used together with Rampant Outrage cosmetic item by adding control point
however I had to add a "RemoveModifier" under "OnSpellStart" or the particle would not be displayed if axe already had the +40 armor modifier