### PR TITLE
Fixed facing direction.

### DIFF
--- a/game/scripts/vscripts/heroes/hero_brewmaster/primal_split.lua
+++ b/game/scripts/vscripts/heroes/hero_brewmaster/primal_split.lua
@@ -141,10 +141,11 @@ end
 -- Ends the the ability, repositioning the hero on the latest active split unit
 function PrimalSplitEnd( event )
 	local caster = event.caster
-
+	local facing_direction = caster.ActiveSplit:GetForwardVector()
 	if caster.ActiveSplit then
 		local position = caster.ActiveSplit:GetAbsOrigin()
 		FindClearSpaceForUnit(caster, position, true)
+		caster:SetForwardVector(facing_direction)
 	end
 
 end


### PR DESCRIPTION
Brewmaster must be facing same direction as the brewling it replaces at the end of the duration. Conformed from 6.85b update patch notes.