### PR TITLE
Reworked gem to only reveal invis enemies to the team that holds it, …

### DIFF
--- a/game/scripts/npc/items/item_gem_datadriven.txt
+++ b/game/scripts/npc/items/item_gem_datadriven.txt
@@ -1,7 +1,6 @@
 // Rewrite of Gem of True Sight
 // Author: Noya
 // Date: February 7, 2015
-
 "item_gem_datadriven"
 {
 	// General
@@ -55,7 +54,7 @@
 			"ThinkInterval"  "0.03"
 			"OnIntervalThink"
 			{
-				"ActOnTargets"
+				"RemoveModifier"
 				{
 					"Target"
 					{
@@ -63,35 +62,24 @@
 						"Radius" 	"%radius"
 						"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
 						"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+						"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
 					}
-				
-					"Action"    
+					"ModifierName"  "modifier_truesight"
+				}
+				"ApplyModifier"
+				{
+					"Target"
 					{
-						"RemoveModifier"
-						{
-							"ModifierName"	"modifier_truesight_reveal"
-							"Target" 		"TARGET"
-						}
-
-						"ApplyModifier"
-						{
-							"ModifierName"	"modifier_truesight_reveal"
-							"Target" 		"TARGET"
-						}
+						"Center"  	"TARGET"
+						"Radius" 	"%radius"
+						"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+						"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+						"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
 					}
+					"ModifierName"  "modifier_truesight"
+                    "Duration"      "0.50"
 				}			
 			}		
 		}
-
-		"modifier_truesight_reveal"
-		{
-			"IsHidden"			"1"
-			"Duration"			"0.5"	//The True Sight effect lingers for 0.5 seconds.
-			"States"
-			{
-				"MODIFIER_STATE_INVISIBLE"	"MODIFIER_STATE_VALUE_DISABLED"
-			}
-		}
 	}
 }
-


### PR DESCRIPTION
…also affects magic immune enemies

Applying modifier_truesight gives vision only to the team who owns the modifier. This works much better for multiteam game modes.

I found that the previous code that removed the invis state was acting very inconsistently when I used it on invulnerable units. 