### PR TITLE
Updated Spectre Haunt + Reality

### DIFF
--- a/game/scripts/npc/abilities/spectre_haunt_datadriven.txt
+++ b/game/scripts/npc/abilities/spectre_haunt_datadriven.txt
@@ -88,7 +88,8 @@
 				"Center"  	"CASTER"
 				"Radius" 	"GLOBAL"
 				"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
-				"Types" 	"DOTA_UNIT_TARGET_HERO" 
+				"Types" 	"DOTA_UNIT_TARGET_HERO"
+				"Flags"		"DOTA_UNIT_TARGET_FLAG_NOT_ILLUSIONS"
 			}
 			"ModifierName" "modifier_spectre_haunt_datadriven"
 		}

--- a/game/scripts/vscripts/heroes/hero_spectre/reality.lua
+++ b/game/scripts/vscripts/heroes/hero_spectre/reality.lua
@@ -19,6 +19,8 @@ function RealityCast (keys)
 			target:SetAbsOrigin(caster.currentPosition)	
 			caster:SetAbsOrigin(target.currentPosition)
 
+			FindClearSpaceForUnit( caster, target.currentPosition, true )
+
 			EmitSoundOn("Hero_Spectre.Reality", caster)
 
 		end

--- a/game/scripts/vscripts/heroes/hero_spectre/reality.lua
+++ b/game/scripts/vscripts/heroes/hero_spectre/reality.lua
@@ -10,6 +10,14 @@ function RealityCast (keys)
 		local target = Entities:FindByNameNearest(unit, vPoint, 0)
 
 		if target:IsIllusion() then
+			
+			--Store the caster and the illusions forward vector
+			local caster_forward_vector = caster:GetForwardVector()
+			local target_forward_vector = target:GetForwardVector()
+
+			--Swaps the forward vector of the caster and the illusion
+			caster:SetForwardVector(target_forward_vector)
+			target:SetForwardVector(caster_forward_vector)
 
 			--Store the caster and the illusions current position
 			caster.currentPosition = caster:GetAbsOrigin()

--- a/game/scripts/vscripts/heroes/hero_spectre/reality.lua
+++ b/game/scripts/vscripts/heroes/hero_spectre/reality.lua
@@ -20,14 +20,14 @@ function RealityCast (keys)
 			target:SetForwardVector(caster_forward_vector)
 
 			--Store the caster and the illusions current position
-			caster.currentPosition = caster:GetAbsOrigin()
-			target.currentPosition = target:GetAbsOrigin()
+			local caster_current_position = caster:GetAbsOrigin()
+			local target_current_position = target:GetAbsOrigin()
 
 			--Swaps the position of the caster and the illusion
-			target:SetAbsOrigin(caster.currentPosition)	
-			caster:SetAbsOrigin(target.currentPosition)
+			target:SetAbsOrigin(caster_current_position)	
+			caster:SetAbsOrigin(target_current_position)
 
-			FindClearSpaceForUnit( caster, target.currentPosition, true )
+			FindClearSpaceForUnit( caster, target_current_position, true )
 
 			EmitSoundOn("Hero_Spectre.Reality", caster)
 


### PR DESCRIPTION
Fixed some small tweaks
-Find clear space for caster (reality.lua)
-Forward vector changes according to the target illusion (reality.lua)
-No longer targets enemy illusions
-Memory management (stored temporary variables locally instead of globally)
