### PR TITLE
Fix visual bug with multiple instance of sun ray

### DIFF
--- a/game/scripts/vscripts/heroes/hero_phoenix/sun_ray.lua
+++ b/game/scripts/vscripts/heroes/hero_phoenix/sun_ray.lua
@@ -41,7 +41,7 @@ function CastSunRay( event )
 
 	-- Create particle FX
 	local particleName = "particles/units/heroes/hero_phoenix/phoenix_sunray.vpcf"
-	pfx = ParticleManager:CreateParticle( particleName, PATTACH_ABSORIGIN_FOLLOW, caster )
+	local pfx = ParticleManager:CreateParticle( particleName, PATTACH_ABSORIGIN_FOLLOW, caster )
 	ParticleManager:SetParticleControlEnt( pfx, 0, caster, PATTACH_POINT_FOLLOW, "attach_hitloc", caster:GetAbsOrigin(), true )
 
 	-- Attach a loop sound to the endcap


### PR DESCRIPTION
Fix bug with multiple instances of sun ray causing the particles to not get destroyed on sun ray end.
pfx was being saved as global value instead of local, thus when a new instance of sun ray was created it would overwrite the old pfx causing the old particles to never be destroyed.